### PR TITLE
Update README.md - Re-enable Swap Memory Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,56 @@ vm.compressor_mode: 2
 
 ***Swap Memory Disabled***
 
-**note: To enable Swap memory back**
 
+# Re-enable Swap Memory:
 
-In the terminal under macOS Recovery:
+## Step 1: Reset Boot Configuration for Swap Memory
+
+Open the Terminal application on your Mac.
+Reset the boot configuration to its default state, which includes enabling swap memory. Execute the following command:
+
 ```bash
-% csrutil enable
+sudo nvram -d boot-args
 ```
+
+This command removes the custom boot arguments that were set to disable swap memory.
+
+## Step 2: Reload dynamic_pager Daemon
+
+The dynamic_pager daemon controls the swap file in macOS. To re-enable it, you need to reload the daemon. In Terminal, execute:
+
+```bash
+sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.dynamic_pager.plist
+```
+
+This command re-enables the daemon, allowing macOS to manage swap files automatically.
+
+## Step 3: Restart Your Mac
+
+After executing these commands, restart your Mac to apply the changes.
+
+## Step 4: Verify Swap Memory Re-activation
+
+After your Mac restarts, open Terminal again and check the compressor mode to ensure that swap memory is re-enabled:
+
+```bash
+sysctl vm.compressor_mode
+```
+
+The output should indicate that both memory compression and swap memory are enabled (typically vm.compressor_mode: 4).
+
+## Optional: Re-enable System Integrity Protection (SIP)
+
+If you previously disabled SIP as part of the process to disable swap memory, you might want to re-enable it for security reasons:
+1. Restart your Mac in Recovery Mode.
+2. Open Terminal from the Utilities menu.
+3. Type the following command to enable SIP:
+
+```bash
+csrutil enable
+```
+
+4. Restart your Mac.
 
 # Reference
 SIP: https://developer.apple.com/documentation/security/disabling_and_enabling_system_integrity_protection


### PR DESCRIPTION
**Pull Request: Re-enable Swap Memory Instructions**

**Description:**
This pull request adds detailed instructions for re-enabling swap memory on macOS. These instructions are designed to be comprehensive and user-friendly, helping individuals who need to reconfigure their swap memory settings on macOS 14 or later.

**Changes Made:**
- Added a step-by-step guide for resetting the boot configuration to enable swap memory.
- Included instructions for reloading the dynamic_pager daemon, essential for managing swap files.
- Explained how to restart the Mac to apply the changes.
- Provided a verification step to ensure swap memory re-activation.
- Optional instructions for re-enabling System Integrity Protection (SIP) for security reasons, if it was previously disabled.

**Reason for Changes:**
In your original version, the last step you provided to enable the swap again was actually just the command to re-enable SIP, not to revert the swap file changes.

These instructions are intended to assist users in optimizing their macOS systems by re-enabling swap memory and reverting previous changes. The steps have been carefully crafted to be clear and concise, making it easier for users to follow.


**Related Issues:**
N/A

**Screenshots:**
N/A

**Additional Information:**
This is my very very first pull request, and I welcome any feedback or suggestions for improvement.

I honestly have no clue what I'm doing so any help is greatly appreciated! Ha!

Please feel free to review and merge if everything looks good.

Thank you!